### PR TITLE
Fixed the write function buffer pointer casting

### DIFF
--- a/FTDI.xcodeproj/project.pbxproj
+++ b/FTDI.xcodeproj/project.pbxproj
@@ -406,7 +406,7 @@
 					"$(PROJECT_DIR)/Sources/FTDI/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2.0;
 				MODULEMAP_FILE = Sources/FTDI/include/FTDI.modulemap;
 				MODULEMAP_PRIVATE_FILE = "";
 				OTHER_CFLAGS = "$(inherited)";
@@ -464,7 +464,7 @@
 					"$(PROJECT_DIR)/Sources/FTDI/lib",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.13;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2.0;
 				MODULEMAP_FILE = Sources/FTDI/include/FTDI.modulemap;
 				MODULEMAP_PRIVATE_FILE = "";
 				OTHER_CFLAGS = "$(inherited)";


### PR DESCRIPTION
- Fixed the pointer casting and passing in the Swift -> C library call with proper UnsafeMutablePointer logic. 
- Removed the RTS setting during the write function, it is unnecessary in the current implementation without flow control.
- Changed the read buffer to allocate only the size of read bytes. 
- Changed the CChar return and buffer type to UInt8 for consistency